### PR TITLE
Add private sale and presale contracts, implement constants contract and add the bonus method

### DIFF
--- a/contracts/LedToken.sol
+++ b/contracts/LedToken.sol
@@ -39,7 +39,6 @@ contract LedToken is Controllable {
   bool public mintingFinished = false;
   bool public presaleBalancesLocked = false;
 
-  uint256 public constant TOTAL_PRESALE_TOKENS = 112386712924725508802400;
   uint256 public totalSupplyAtCheckpoint;
 
   event Mint(address indexed to, uint256 amount);

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -10,7 +10,7 @@ import './TokenInfo.sol';
 
  * on a token per ETH rate. Funds collected are forwarded to a wallet as they arrive.
  */
-contract TokenSale is Pausable, TokenInfo {
+contract Presale is Pausable, TokenInfo {
 
   using SafeMath for uint256;
 
@@ -23,16 +23,15 @@ contract TokenSale is Pausable, TokenInfo {
   uint256 public startTime;
   uint256 public endTime;
   uint256 public surplusTokens;
-  uint256 public allocatedTokens;
 
   bool public finalized;
 
   bool public ledTokensAllocated;
   address public ledMultiSig = LED_MULTISIG;
 
-  uint256 public tokenCap = ICO_TOKENCAP;
+  uint256 public tokenCap = PRESALE_TOKENCAP;
   uint256 public cap = tokenCap * (10 ** 18);
-  uint256 public weiCap = tokenCap * ICO_BASE_PRICE_IN_WEI;
+  uint256 public weiCap = tokenCap * PRESALE_BASE_PRICE_IN_WEI;
 
   bool public started = false;
 
@@ -43,7 +42,7 @@ contract TokenSale is Pausable, TokenInfo {
   event LogInt(string _name, uint256 _value);
   event Finalized();
 
-  function TokenSale(address _tokenAddress, uint256 _startTime, uint256 _endTime) public {
+  function Presale(address _tokenAddress, uint256 _startTime, uint256 _endTime) public {
     require(_tokenAddress != 0x0);
     require(_startTime > 0);
     require(_endTime > _startTime);
@@ -72,7 +71,7 @@ contract TokenSale is Pausable, TokenInfo {
     require(validPurchase());
 
     uint256 weiAmount = msg.value;
-    uint256 priceInWei = ICO_BASE_PRICE_IN_WEI;
+    uint256 priceInWei = PRESALE_BASE_PRICE_IN_WEI;
     totalWeiRaised = totalWeiRaised.add(weiAmount);
 
     uint256 bonusPercentage = determineBonus(weiAmount);
@@ -91,23 +90,23 @@ contract TokenSale is Pausable, TokenInfo {
   }
 
   function determineBonus(uint256 _wei) constant public returns (uint256) {
-    if(_wei > ICO_LEVEL_1) {
-      if(_wei > ICO_LEVEL_2) {
-        if(_wei > ICO_LEVEL_3) {
-          if(_wei > ICO_LEVEL_4) {
-            if(_wei > ICO_LEVEL_5) {
-              return ICO_PERCENTAGE_5;
+    if(_wei > PRESALE_LEVEL_1) {
+      if(_wei > PRESALE_LEVEL_2) {
+        if(_wei > PRESALE_LEVEL_3) {
+          if(_wei > PRESALE_LEVEL_4) {
+            if(_wei > PRESALE_LEVEL_5) {
+              return PRESALE_PERCENTAGE_5;
             } else {
-              return ICO_PERCENTAGE_4;
+              return PRESALE_PERCENTAGE_4;
             }
           } else {
-            return ICO_PERCENTAGE_3;
+            return PRESALE_PERCENTAGE_3;
           }
         } else {
-          return ICO_PERCENTAGE_2;
+          return PRESALE_PERCENTAGE_2;
         }
       } else {
-        return ICO_PERCENTAGE_1;
+        return PRESALE_PERCENTAGE_1;
       }
     } else {
       return 0;
@@ -161,19 +160,6 @@ contract TokenSale is Pausable, TokenInfo {
     ledToken.transferControl(_newController);
   }
 
-
-  function enableTransfers() public {
-    if (now < endTime) {
-      require(msg.sender == owner);
-    }
-    ledToken.enableTransfers(true);
-  }
-
-  function lockTransfers() public onlyOwner {
-    require(now < endTime);
-    ledToken.enableTransfers(false);
-  }
-
   function enableMasterTransfers() public onlyOwner {
     ledToken.enableMasterTransfers(true);
   }
@@ -186,21 +172,11 @@ contract TokenSale is Pausable, TokenInfo {
     started = true;
   }
 
-  function allocateLedTokens() public onlyOwner whenNotFinalized {
-    require(!ledTokensAllocated);
-    allocatedTokens = LEDTEAM_TOKENS.mul(decimalsMultiplier);
-    ledToken.mint(ledMultiSig, allocatedTokens);
-    surplusTokens = cap - tokensMinted;
-    ledToken.mint(ledMultiSig, surplusTokens);
-    ledTokensAllocated = true;
-  }
-
   function finalize() public onlyOwner {
     require(paused);
-    require(ledTokensAllocated);
+    surplusTokens = cap - tokensMinted;
+    ledToken.mint(ledMultiSig, surplusTokens);
 
-    ledToken.finishMinting();
-    ledToken.enableTransfers(true);
     Finalized();
 
     finalized = true;

--- a/contracts/TokenInfo.sol
+++ b/contracts/TokenInfo.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.4.13;
+
+contract TokenInfo {
+    // Base prices in wei, going off from an Ether value of $678.77
+    uint256 public constant PRIVATESALE_BASE_PRICE_IN_WEI = 294542134252305;
+    uint256 public constant PRESALE_BASE_PRICE_IN_WEI = 441813201378457;
+    uint256 public constant ICO_BASE_PRICE_IN_WEI = 589084268504609;
+
+    // Bonus percentages for each respective sale level
+    uint256 public constant PRIVATESALE_PERCENTAGE_1 = 20;
+    uint256 public constant PRIVATESALE_PERCENTAGE_2 = 25;
+    uint256 public constant PRIVATESALE_PERCENTAGE_3 = 35;
+    uint256 public constant PRIVATESALE_PERCENTAGE_4 = 50;
+    uint256 public constant PRIVATESALE_PERCENTAGE_5 = 100;
+
+    uint256 public constant PRESALE_PERCENTAGE_1 = 10;
+    uint256 public constant PRESALE_PERCENTAGE_2 = 15;
+    uint256 public constant PRESALE_PERCENTAGE_3 = 20;
+    uint256 public constant PRESALE_PERCENTAGE_4 = 25;
+    uint256 public constant PRESALE_PERCENTAGE_5 = 35;
+
+    uint256 public constant ICO_PERCENTAGE_1 = 5;
+    uint256 public constant ICO_PERCENTAGE_2 = 10;
+    uint256 public constant ICO_PERCENTAGE_3 = 15;
+    uint256 public constant ICO_PERCENTAGE_4 = 20;
+    uint256 public constant ICO_PERCENTAGE_5 = 25;
+
+    // Bonus levels in wei for each respective level
+    uint256 public constant PRIVATESALE_LEVEL_1 = 2400000000000000000;
+    uint256 public constant PRIVATESALE_LEVEL_2 = 5000000000000000000;
+    uint256 public constant PRIVATESALE_LEVEL_3 = 8100000000000000000;
+    uint256 public constant PRIVATESALE_LEVEL_4 = 12000000000000000000;
+    uint256 public constant PRIVATESALE_LEVEL_5 = 20000000000000000000;
+
+    uint256 public constant PRESALE_LEVEL_1 = 3000000000000000000;
+    uint256 public constant PRESALE_LEVEL_2 = 6000000000000000000;
+    uint256 public constant PRESALE_LEVEL_3 = 9000000000000000000;
+    uint256 public constant PRESALE_LEVEL_4 = 12000000000000000000;
+    uint256 public constant PRESALE_LEVEL_5 = 15000000000000000000;
+
+    uint256 public constant ICO_LEVEL_1 = 4000000000000000000;
+    uint256 public constant ICO_LEVEL_2 = 8000000000000000000;
+    uint256 public constant ICO_LEVEL_3 = 12000000000000000000;
+    uint256 public constant ICO_LEVEL_4 = 16000000000000000000;
+    uint256 public constant ICO_LEVEL_5 = 20000000000000000000;
+
+    // Caps for the respective sales, the amount of tokens allocated to the team and the total cap
+    uint256 public constant PRIVATESALE_TOKENCAP = 23750000;
+    uint256 public constant PRESALE_TOKENCAP = 18750000;
+    uint256 public constant ICO_TOKENCAP = 22500000;
+    uint256 public constant LEDTEAM_TOKENS = 35000000;
+    uint256 public constant TOTAL_TOKENCAP = 100000000;
+
+    address public constant LED_MULTISIG = 0x9c0e9941a4c554f6e1aa1930268a7c992e3c8602;
+}

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -190,7 +190,8 @@ contract TokenSale is Pausable, TokenInfo {
 
   function allocateLedTokens() public onlyOwner whenNotFinalized {
     require(!ledTokensAllocated);
-    ledToken.mint(ledMultiSig, LEDTEAM_TOKENS);
+    uint256 ledTeamTokens = LEDTEAM_TOKENS.mul(decimalsMultiplier);
+    ledToken.mint(ledMultiSig, ledTeamTokens);
     ledTokensAllocated = true;
   }
 

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -190,7 +190,7 @@ contract TokenSale is Pausable, TokenInfo {
 
   function allocateLedTokens() public onlyOwner whenNotFinalized {
     require(!ledTokensAllocated);
-    ledToken.mint(ledMultiSig, TOKENS_ALLOCATED_TO_LED);
+    ledToken.mint(ledMultiSig, LEDTEAM_TOKENS);
     ledTokensAllocated = true;
   }
 


### PR DESCRIPTION
Will add tokensale contracts for other 2 sales, all 3 sales will inherit the constants from the TokenInfo contract, and all tokensales now have the bonus method as described by Evan, instead of the discount cap model from the earlier versions.