### PR TITLE
Refactor private sale

### DIFF
--- a/contracts/PrivateSale.sol
+++ b/contracts/PrivateSale.sol
@@ -47,17 +47,7 @@ contract PrivateSale is Crowdsale {
     uint256 priceInWei = PRIVATESALE_BASE_PRICE_IN_WEI;
     totalWeiRaised = totalWeiRaised.add(weiAmount);
 
-    uint256 bonusPercentage = determineBonus(weiAmount);
-    uint256 bonusTokens;
-
-    uint256 initialTokens = weiAmount.mul(DECIMALS_MULTIPLIER).div(priceInWei);
-    if(bonusPercentage>0){
-      uint256 initialDivided = initialTokens.div(100);
-      bonusTokens = initialDivided.mul(bonusPercentage);
-    } else {
-      bonusTokens = 0;
-    }
-    uint256 tokens = initialTokens.add(bonusTokens);
+    uint256 tokens = weiAmount.mul(DECIMALS_MULTIPLIER).div(priceInWei);
     tokensMinted = tokensMinted.add(tokens);
     require(tokensMinted < cap);
 
@@ -66,30 +56,6 @@ contract PrivateSale is Crowdsale {
     ledToken.mint(_beneficiary, tokens);
     emit TokenPurchase(msg.sender, _beneficiary, weiAmount, tokens);
     forwardFunds();
-  }
-
-  function determineBonus(uint256 _wei) public view returns (uint256) {
-    if(_wei > PRIVATESALE_LEVEL_1) {
-      if(_wei > PRIVATESALE_LEVEL_2) {
-        if(_wei > PRIVATESALE_LEVEL_3) {
-          if(_wei > PRIVATESALE_LEVEL_4) {
-            if(_wei > PRIVATESALE_LEVEL_5) {
-              return PRIVATESALE_PERCENTAGE_5;
-            } else {
-              return PRIVATESALE_PERCENTAGE_4;
-            }
-          } else {
-            return PRIVATESALE_PERCENTAGE_3;
-          }
-        } else {
-          return PRIVATESALE_PERCENTAGE_2;
-        }
-      } else {
-        return PRIVATESALE_PERCENTAGE_1;
-      }
-    } else {
-      return 0;
-    }
   }
 
   function finalize() public onlyOwner {
@@ -120,22 +86,6 @@ contract PrivateSale is Crowdsale {
       started,
       startTime, // Start time and end time in Unix timestamp format with a length of 10 numbers.
       endTime
-    );
-  }
-  
-  function getInfoLevels() public view returns(uint256, uint256, uint256, uint256, uint256, uint256, 
-  uint256, uint256, uint256, uint256){
-    return (
-      PRIVATESALE_LEVEL_1, // Amount of ether needed per bonus level
-      PRIVATESALE_LEVEL_2,
-      PRIVATESALE_LEVEL_3,
-      PRIVATESALE_LEVEL_4,
-      PRIVATESALE_LEVEL_5,
-      PRIVATESALE_PERCENTAGE_1, // Bonus percentage per bonus level
-      PRIVATESALE_PERCENTAGE_2,
-      PRIVATESALE_PERCENTAGE_3,
-      PRIVATESALE_PERCENTAGE_4,
-      PRIVATESALE_PERCENTAGE_5
     );
   }
 

--- a/contracts/TokenInfo.sol
+++ b/contracts/TokenInfo.sol
@@ -2,22 +2,17 @@ pragma solidity ^0.4.24;
 
 contract TokenInfo {
     // Base prices in wei, going off from an Ether value of $500
-    uint256 public constant PRIVATESALE_BASE_PRICE_IN_WEI = 400000000000000;
+    uint256 public constant PRIVATESALE_BASE_PRICE_IN_WEI = 200000000000000;
     uint256 public constant PRESALE_BASE_PRICE_IN_WEI = 600000000000000;
     uint256 public constant ICO_BASE_PRICE_IN_WEI = 800000000000000;
     uint256 public constant FIRSTSALE_BASE_PRICE_IN_WEI = 200000000000000;
 
     // First sale minimum and maximum contribution, going off from an Ether value of $500
-    uint256 public constant MIN_PURCHASE_OTHERSALES = 200000000000000000;
+    uint256 public constant MIN_PURCHASE_OTHERSALES = 80000000000000000;
     uint256 public constant MIN_PURCHASE = 1000000000000000000;
     uint256 public constant MAX_PURCHASE = 1000000000000000000000;
 
     // Bonus percentages for each respective sale level
-    uint256 public constant PRIVATESALE_PERCENTAGE_1 = 20;
-    uint256 public constant PRIVATESALE_PERCENTAGE_2 = 25;
-    uint256 public constant PRIVATESALE_PERCENTAGE_3 = 35;
-    uint256 public constant PRIVATESALE_PERCENTAGE_4 = 50;
-    uint256 public constant PRIVATESALE_PERCENTAGE_5 = 100;
 
     uint256 public constant PRESALE_PERCENTAGE_1 = 10;
     uint256 public constant PRESALE_PERCENTAGE_2 = 15;
@@ -32,11 +27,6 @@ contract TokenInfo {
     uint256 public constant ICO_PERCENTAGE_5 = 25;
 
     // Bonus levels in wei for each respective level
-    uint256 public constant PRIVATESALE_LEVEL_1 = 4000000000000000000;
-    uint256 public constant PRIVATESALE_LEVEL_2 = 8333333333333333333;
-    uint256 public constant PRIVATESALE_LEVEL_3 = 13500000000000000000;
-    uint256 public constant PRIVATESALE_LEVEL_4 = 20000000000000000000;
-    uint256 public constant PRIVATESALE_LEVEL_5 = 33333333333333333333;
 
     uint256 public constant PRESALE_LEVEL_1 = 5000000000000000000;
     uint256 public constant PRESALE_LEVEL_2 = 10000000000000000000;


### PR DESCRIPTION
- Set private sale bonus to %100, removed tiered bonuses
- Made the minimum buy requirement 0.08 eth, to cover for gas costs